### PR TITLE
fix(ralph): wrap the whole command line for cmd.exe

### DIFF
--- a/.claude/ralph-start.js
+++ b/.claude/ralph-start.js
@@ -175,9 +175,17 @@ function shimSpawnArgs(file, args) {
     const text = String(a);
     return safe.test(text) ? text : '"' + text.split('"').join('""') + '"';
   });
+  // The whole command line gets one more pair of quotes around it. With /s, cmd.exe
+  // strips the first quote and the LAST quote on the line and runs what is left
+  // verbatim - so without the wrapper it eats a quote belonging to an argument. That
+  // is not theoretical: `--tools "Bash,PowerShell,..."` made cmd read
+  // `claude" -p ... --tools "Bash` as the program name and the first real run died
+  // before it started. It stayed hidden while every argument happened to be
+  // quote-free, because then the only quotes on the line were the pair around the
+  // program name.
   return [
     process.env.ComSpec || 'cmd.exe',
-    ['/d', '/s', '/c', `"${file}" ${quoted.join(' ')}`],
+    ['/d', '/s', '/c', `""${file}" ${quoted.join(' ')}"`],
     { windowsVerbatimArguments: true },
   ];
 }

--- a/.claude/tests/helpers.test.js
+++ b/.claude/tests/helpers.test.js
@@ -175,3 +175,40 @@ test('shimSpawnArgs quotes arguments that would otherwise reach the shell', {
   );
   assert.ok(line.includes('--model sonnet'), line);
 });
+
+test('shimSpawnArgs survives cmd.exe eating the last quote on the line', {
+  skip: process.platform !== 'win32' && 'cmd.exe quoting is Windows-only',
+}, () => {
+  // The bug this guards: with /s, cmd strips the first quote and the LAST quote on the
+  // command line and runs the rest verbatim. As long as the only quotes were the pair
+  // around the program name that was harmless. Add a quoted argument - a comma-joined
+  // --tools list is one - and cmd instead ate that argument's closing quote, leaving
+  // `claude" -p ... --tools "Bash` as the program name. Nothing ran.
+  const [, args] = ralph.shimSpawnArgs('claude', [
+    '-p',
+    '--tools',
+    'Bash,PowerShell,Read',
+    '--disallowedTools',
+    'Task,Skill',
+    '--allowedTools',
+    'Bash',
+    'Read',
+  ]);
+  const command = args[args.length - 1];
+
+  assert.ok(command.startsWith('"'), `no leading quote to sacrifice: ${command}`);
+  assert.ok(command.endsWith('"'), `no trailing quote to sacrifice: ${command}`);
+
+  // What cmd.exe /s does, applied here: drop the first quote, drop the last quote.
+  const afterCmd = command.slice(1, command.lastIndexOf('"'));
+  assert.ok(afterCmd.startsWith('"claude"'), `program name mangled: ${afterCmd}`);
+  assert.ok(
+    afterCmd.includes('--tools "Bash,PowerShell,Read"'),
+    `tool list lost a quote: ${afterCmd}`,
+  );
+  assert.ok(
+    afterCmd.includes('--disallowedTools "Task,Skill"'),
+    `deny list lost a quote: ${afterCmd}`,
+  );
+  assert.ok(afterCmd.trimEnd().endsWith('--allowedTools Bash Read'), afterCmd);
+});

--- a/.claude/tests/session.test.js
+++ b/.claude/tests/session.test.js
@@ -174,7 +174,8 @@ test('--allowedTools stays last, because it is variadic', async () => {
     assert.ok(at >= 0);
     const tail = flat.slice(at + '--allowedTools'.length);
     assert.doesNotMatch(tail, /--/, `a flag follows --allowedTools: ${tail}`);
-    assert.ok(flat.trimEnd().endsWith('Bash'), flat);
+    // On Windows the last character is the wrapper quote cmd.exe /s consumes.
+    assert.ok(flat.trimEnd().replace(/"$/, '').endsWith('Bash'), flat);
   } finally {
     restore();
   }


### PR DESCRIPTION
The first canary run died in four seconds, before starting a session, having spent $0.00:

```
'claude" -p --output-format stream-json --verbose --model sonnet --max-turns 100
 --exclude-dynamic-system-prompt-sections --tools "Bash' is not recognized as an
 internal or external command
```

## Why

`shimSpawnArgs` builds a `cmd.exe /d /s /c <line>` invocation for the `claude` and `pnpm` shims. With `/s`, cmd strips the **first** quote and the **last** quote on the line and runs the rest verbatim.

While every argument happened to be quote-free, the only quotes on the line were the pair around the program name, and cmd's rule happened to remove exactly those. The tool lists introduced by the issue pipeline (`--tools "Bash,PowerShell,..."`, `--disallowedTools "Task,Skill"`) are quoted because of their commas, so cmd consumed one of *their* closing quotes instead and read `claude" -p ... --tools "Bash` as the program name.

This affected the gate as well: any changed file with a space in its path would have quoted an argument to `pnpm` and broken the same way.

## The fix

One more pair of quotes around the whole command line, so cmd has something of ours to consume. This is what Node itself does for `shell: true` on Windows.

## Verification

- A new test models cmd's rule directly: it strips the first and last quote of the built line and asserts the program name and both tool lists survive intact.
- Verified against the real `cmd.exe`, not just the model of it: the shimmed argv now reaches `claude` and it prints its help (exit 0). That also confirms the CLI accepts `--tools`, `--disallowedTools` and `--disable-slash-commands` together, which could not be checked offline.
- 107 orchestrator tests pass.

The canary is worth what it cost: nothing, and it found this on the first attempt. Everything downstream behaved correctly — the run failed closed, wrote a checkpoint, spent no money and left the phase branch untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
