### PR TITLE
fix(ralph): let an interrupted issue actually be resumed

### DIFF
--- a/.claude/ralph-start.js
+++ b/.claude/ralph-start.js
@@ -1159,6 +1159,71 @@ const DIRT_EXPLAINED_BY = new Set([
 ]);
 
 /**
+ * A checkpoint is worth honouring only while it still has something at stake: a commit
+ * it left behind, or work sitting in the tree. One with neither is not contradicted by a
+ * moved HEAD, it is simply older than the branch - the loop merges the trunk in at the
+ * start of every phase, so that is the ordinary case after an interruption rather than
+ * an anomaly. Pinning an anchor from such a checkpoint is what stopped a canary run that
+ * had done nothing wrong.
+ */
+const checkpointAtStake = (saved, dirty) =>
+  !!(saved && saved.issue && (saved.commitSha || dirty));
+
+/**
+ * The files a run's behaviour actually comes out of. A branch whose copies match the
+ * trunk's runs the same loop the trunk would, which is the only thing the branch guard
+ * is really protecting.
+ */
+const ORCHESTRATOR_FILES = [
+  '.claude/ralph-start.js',
+  '.claude/ralph.config.json',
+  '.claude/ralph.md',
+];
+
+/** Which of those files this branch has in a different version from the trunk. */
+function orchestratorDrift(base) {
+  const trunk = refExists(`refs/remotes/origin/${base}`) ? `origin/${base}` : base;
+  return ORCHESTRATOR_FILES.filter((file) => {
+    const here = gitTry('rev-parse', `HEAD:${file}`);
+    const there = gitTry('rev-parse', `${trunk}:${file}`);
+    // A file one side does not have at all is a difference worth stopping for.
+    return here.code !== 0 || there.code !== 0 || here.stdout !== there.stdout;
+  });
+}
+
+/**
+ * Where a run may start.
+ *
+ * Normally the trunk and nowhere else: the orchestrator lives in .claude/, which is
+ * versioned per branch, and a finished run leaves the tree on a phase branch - starting
+ * from there would silently execute that branch's older copy of this file.
+ *
+ * A resume is the exception, and it has to be, because the two rules are otherwise
+ * incompatible. An interrupted issue's work is uncommitted on the phase branch, and git
+ * refuses to carry a file the trunk does not have back to the trunk - which is every
+ * issue that adds one. The canary hit exactly this: the checkpoint stood at
+ * ISSUE_REVIEW, and the only way back to the trunk was to stash away the very work the
+ * checkpoint existed to protect.
+ *
+ * So the loop may start from the branch its own checkpoint names - once the files that
+ * decide its behaviour are shown to be the trunk's, which is what the guard was for.
+ */
+function startupBranchRefusal(current, base, checkpoint, drift) {
+  if (current === base) return null;
+  const from = `Start the loop from ${base}, not ${current}.`;
+  if (!checkpoint) {
+    return `${from} A previous run leaves the tree on its phase branch, and running from there would use that branch's copy of the orchestrator.`;
+  }
+  if (checkpoint.branch !== current) {
+    return `${from} The checkpoint in ${paths.state} belongs to ${checkpoint.branch}, so this is neither the trunk nor the branch being resumed.`;
+  }
+  if (drift.length > 0) {
+    return `${current} carries its own version of ${drift.join(', ')}, so resuming here would run a different loop than ${base} does. Merge ${base} into ${current} first, then re-run.`;
+  }
+  return null;
+}
+
+/**
  * Writes the checkpoint atomically: a temporary file in the same directory, then a
  * rename, so a run killed mid-write leaves either the old checkpoint or the new one and
  * never a half-written one. A failure here is logged rather than thrown - losing the
@@ -2096,8 +2161,17 @@ async function runPhase(phase, cfg, opts, base, budget) {
   // it here is what lets prepareIssue accept the tree the interrupted attempt left: the
   // dirt is that issue's own work, and re-anchoring on HEAD would hide it from the gate,
   // the reviewer and the commit.
-  const resume = stateFor(cfg, phase);
-  if (resume && resume.issue && resume.issueBaseSha) {
+  const saved = stateFor(cfg, phase);
+  const resume = checkpointAtStake(saved, git('status', '--porcelain').stdout)
+    ? saved
+    : null;
+  if (saved && !resume) {
+    log(
+      `  checkpoint for issue #${saved.issue} at ${saved.stage} has nothing left in the tree, starting the phase normally`,
+    );
+    clearState();
+  }
+  if (resume) {
     budget.baseSha.set(resume.issue, resume.issueBaseSha);
     log(
       `  checkpoint: issue #${resume.issue} at ${resume.stage}, base ${resume.issueBaseSha.slice(0, 8)}, written ${resume.updatedAt}`,
@@ -2112,8 +2186,19 @@ async function runPhase(phase, cfg, opts, base, budget) {
     `> Phase ${phase.index} "${phase.milestone}" . branch ${phase.branch} . ${openBefore.length} open issue(s) . budget ${fmtTokens(budget.phaseLimit)}`,
   );
 
-  prepareFeatureBranch(cfg, base);
-  preparePhaseBranch(phase, cfg);
+  if (resume) {
+    // Re-syncing the branches merges the trunk in, and that moves HEAD - out from under
+    // the anchor the checkpoint measured its issue from, so the resume then refuses
+    // itself. Those merges belong to the start of a phase, not to the middle of an
+    // issue; the next phase picks them up.
+    if (git('rev-parse', '--abbrev-ref', 'HEAD').stdout !== phase.branch) {
+      git('switch', phase.branch);
+    }
+    log(`  mid-issue: leaving ${phase.branch} where the checkpoint left it, no trunk merge`);
+  } else {
+    prepareFeatureBranch(cfg, base);
+    preparePhaseBranch(phase, cfg);
+  }
 
   await drainIssues(phase, cfg, opts, budget);
   await reviewPhase(phase, cfg, opts, budget);
@@ -2360,13 +2445,15 @@ async function main() {
     return;
   }
 
-  // The orchestrator lives in .claude/, which is versioned per branch, and a finished
-  // run leaves the tree on a phase branch. Starting from there would silently execute
-  // that branch's older copy of this file and its config.
   const current = git('rev-parse', '--abbrev-ref', 'HEAD').stdout;
   if (current !== base) {
-    fail(
-      `Start the loop from ${base}, not ${current}. A previous run leaves the tree on its phase branch, and running from there would use that branch's copy of the orchestrator.`,
+    // Only worth the round trip when the answer might be yes, but then it has to be
+    // fresh: a stale origin/<base> would compare against a trunk nobody is running.
+    git('fetch', 'origin', '--prune', '--quiet');
+    const refusal = startupBranchRefusal(current, base, checkpoint, orchestratorDrift(base));
+    if (refusal) fail(refusal);
+    log(
+      `| resuming on ${current}: its ${ORCHESTRATOR_FILES.length} orchestrator files match ${base}`,
     );
   }
 
@@ -2508,6 +2595,11 @@ module.exports = {
   clearState,
   stateFor,
   startupTreeRefusal,
+  startupBranchRefusal,
+  checkpointAtStake,
+  runPhase,
+  orchestratorDrift,
+  ORCHESTRATOR_FILES,
   STAGES,
   DIRT_EXPLAINED_BY,
   STATE_SCHEMA_VERSION,

--- a/.claude/tests/helpers/fake-repo.js
+++ b/.claude/tests/helpers/fake-repo.js
@@ -39,7 +39,12 @@ function fakeRepo(opts = {}) {
     stateAfterClose: opts.stateAfterClose || 'CLOSED',
     commits: [],
     gateRuns: [],
+    merges: [],
     calls: [],
+    // Which refs exist, matched as substrings: the phase branch does, its tag does not,
+    // so a phase reads as unfinished rather than already merged.
+    refs: opts.refs || ['refs/heads/'],
+    merged: !!opts.merged,
   };
 
   const fn = (file, args = []) => {
@@ -50,7 +55,18 @@ function fakeRepo(opts = {}) {
     if (file === 'git') {
       const [verb] = argv;
       if (verb === 'rev-parse' && argv.includes('--abbrev-ref')) return ok(state.branch);
+      // `--verify --quiet <ref>` is refExists, and answering "yes" to everything makes a
+      // phase look already merged, which silently skips the code under test.
+      if (verb === 'rev-parse' && argv.includes('--verify')) {
+        const ref = argv[argv.length - 1];
+        return state.refs.some((r) => ref.includes(r)) ? ok(state.head) : bad('');
+      }
       if (verb === 'rev-parse') return ok(state.head);
+      if (verb === 'merge-base') return state.merged ? ok() : bad('');
+      if (verb === 'merge') {
+        state.merges.push(line);
+        return ok();
+      }
       if (verb === 'status') return ok(state.dirty);
       if (verb === 'add') return ok();
       if (verb === 'diff') return ok(state.files.join('\n'));

--- a/.claude/tests/state.test.js
+++ b/.claude/tests/state.test.js
@@ -547,3 +547,129 @@ test('no test ever leaves a checkpoint in the repository', async () => {
   assert.equal(fs.existsSync(real), before, 'the repository checkout is untouched');
   assert.equal(fs.existsSync(`${real}.tmp`), false);
 });
+
+// ─── the branch a resume may start from ────────────────────────────────────────
+
+const CHECKPOINT = { branch: 'feature/user-profile-phase-4', stage: 'ISSUE_REVIEW', issue: 41 };
+
+test('the trunk is always a valid place to start', () => {
+  assert.equal(ralph.startupBranchRefusal('master', 'master', null, []), null);
+  assert.equal(ralph.startupBranchRefusal('master', 'master', CHECKPOINT, ['x']), null);
+});
+
+test('without a checkpoint a phase branch is still refused', () => {
+  // The original guard, unchanged: a finished run leaves the tree on a phase branch,
+  // and starting there would execute that branch's own older copy of the loop.
+  const refusal = ralph.startupBranchRefusal('feature/user-profile-phase-4', 'master', null, []);
+  assert.match(refusal, /Start the loop from master/);
+  assert.match(refusal, /that branch's copy of the orchestrator/);
+});
+
+test('a resume may start from the branch its own checkpoint names', () => {
+  // Why this exception has to exist: the interrupted issue's work is uncommitted on the
+  // phase branch, and git will not carry a file the trunk does not have back to the
+  // trunk. The canary stood at ISSUE_REVIEW with no way back except stashing away the
+  // very work the checkpoint was protecting.
+  assert.equal(
+    ralph.startupBranchRefusal('feature/user-profile-phase-4', 'master', CHECKPOINT, []),
+    null,
+  );
+});
+
+test('a resume is refused from a branch the checkpoint does not name', () => {
+  const refusal = ralph.startupBranchRefusal('feature/other-phase-2', 'master', CHECKPOINT, []);
+  assert.match(refusal, /belongs to feature\/user-profile-phase-4/);
+});
+
+test('a branch running its own copy of the loop is refused, and told what to do', () => {
+  const refusal = ralph.startupBranchRefusal(
+    'feature/user-profile-phase-4',
+    'master',
+    CHECKPOINT,
+    ['.claude/ralph-start.js'],
+  );
+  assert.match(refusal, /its own version of \.claude\/ralph-start\.js/);
+  assert.match(refusal, /Merge master into feature\/user-profile-phase-4 first/);
+});
+
+test('orchestratorDrift compares the files behaviour comes out of', () => {
+  // Against the real repository: HEAD and origin/master agree here, or the working
+  // branch is deliberately ahead - either way the answer must be a list, not a throw.
+  const drift = ralph.orchestratorDrift('master');
+  assert.ok(Array.isArray(drift));
+  for (const file of drift) assert.ok(ralph.ORCHESTRATOR_FILES.includes(file), file);
+});
+
+// ─── a resume must not move the ground under itself ────────────────────────────
+
+test('a checkpoint counts only while it has something at stake', () => {
+  const mid = { issue: 41, stage: 'ISSUE_REVIEW', commitSha: null };
+  assert.equal(ralph.checkpointAtStake(mid, LEFTOVERS), true, 'work in the tree');
+  assert.equal(ralph.checkpointAtStake(mid, ''), false, 'nothing left of it');
+  // A commit is at stake even with a clean tree: the issue still has to be closed.
+  assert.equal(
+    ralph.checkpointAtStake({ issue: 41, stage: 'CLOSE_ISSUE', commitSha: 'abc' }, ''),
+    true,
+  );
+  assert.equal(ralph.checkpointAtStake(null, LEFTOVERS), false);
+  assert.equal(ralph.checkpointAtStake({ stage: 'PHASE_REVIEW' }, LEFTOVERS), false);
+});
+
+/** Runs one phase far enough to see how it prepared the branches, then lets it stop. */
+async function phaseUpToDrain({ state, repo = {} }) {
+  const spawnSync = fakeRepo({ dirty: state ? LEFTOVERS : '', ...repo });
+  const paths = withTempPaths(ralph);
+  const loud = quiet();
+  const restore = withFakes(ralph, {
+    spawnSync,
+    spawn: fakeSpawn({ fixtures: ['session-impl', 'session-review-approved'] }),
+  });
+  if (state) fs.writeFileSync(paths.state, JSON.stringify(state));
+  try {
+    // --issues 0 stops it inside drainIssues, after the branch preparation under test.
+    await ralph
+      .runPhase(PHASE, config(), { issues: 0, stopOnLimit: false }, 'master', newBudget())
+      .catch(() => {});
+    return spawnSync.state;
+  } finally {
+    restore();
+    loud();
+    paths.restore();
+  }
+}
+
+const checkpointFor = (over) => ({
+  schemaVersion: 1,
+  feature: ralph.loadConfig('.claude/ralph.config.json').feature,
+  phase: PHASE.index,
+  milestone: PHASE.milestone,
+  branch: PHASE.branch,
+  issue: 41,
+  issueBaseSha: 'base00000000',
+  stage: 'ISSUE_REVIEW',
+  reviewRound: null,
+  commitSha: null,
+  commitSubject: null,
+  updatedAt: '2026-08-20T18:00:00.000Z',
+  ...over,
+});
+
+test('a phase resumed mid-issue does not merge the trunk in', async () => {
+  // The merges belong to the start of a phase. Run under an interrupted issue they move
+  // HEAD out from under the anchor the checkpoint measured that issue from, and the
+  // resume then refuses itself - which is what the canary hit twice.
+  const repo = await phaseUpToDrain({ state: checkpointFor() });
+  assert.deepEqual(repo.merges, [], `merged anyway: ${repo.merges.join(' | ')}`);
+});
+
+test('a phase with no live checkpoint prepares its branches as usual', async () => {
+  const repo = await phaseUpToDrain({ state: null });
+  assert.ok(repo.merges.length > 0, 'the trunk was never merged in');
+});
+
+test('a checkpoint with nothing left in the tree does not hold the phase back', async () => {
+  // Same checkpoint, empty tree: the phase must start normally rather than pin an
+  // anchor that no longer describes anything.
+  const repo = await phaseUpToDrain({ state: checkpointFor(), repo: { dirty: '' } });
+  assert.ok(repo.merges.length > 0, 'a spent checkpoint still blocked the merge');
+});

--- a/docs/ralph-loop-rework/usage.md
+++ b/docs/ralph-loop-rework/usage.md
@@ -194,18 +194,37 @@ the issue:
 | `CLOSE_ISSUE` / `VERIFY_CLOSED`         | closes and verifies only; the commit already exists            |
 | the issue is already closed on GitHub   | marks it done; no model session at all                         |
 | `PHASE_REVIEW`                          | reviews the phase again (a phase review writes nothing)         |
-| `HEAD` is not where the checkpoint says | **stops**, with both SHAs in the message                        |
+| `HEAD` is not where the checkpoint says, and the checkpoint still has work or a commit at stake | **stops**, with both SHAs in the message |
+| `HEAD` has moved but the checkpoint left nothing behind | drops it and starts the issue from here |
 
 The checkpoint is deleted **only** after GitHub confirms the issue closed, or once the
-phase is merged. Two consequences worth knowing:
+phase is merged. Three consequences worth knowing:
 
 - **The tree may legitimately be dirty at startup.** The clean-tree guard is relaxed
   exactly when a checkpoint stands at a stage that leaves work in the tree (`IMPLEMENT`
   through `COMMIT`). At any other stage, or with no checkpoint at all, the loop still
-  refuses to start. The other half of that guard is unchanged: **start the loop from
-  `master`**, never from a phase branch, or it runs that branch's older copy of the
-  orchestrator. `git switch master` carries the uncommitted work across with you; the
-  checkpoint then explains it and the phase branch is re-entered with the work intact.
+  refuses to start.
+- **Resuming, you stay where the loop left you.** Normally you start a run from `master`
+  and nowhere else, or the loop executes the phase branch's own older copy of itself.
+  But an interrupted issue's work is uncommitted *on the phase branch*, and git will not
+  carry a file `master` does not have back to `master` — which is every issue that adds
+  one. So a run may also start from the branch its own checkpoint names, and the loop
+  checks what the guard was really protecting: that `.claude/ralph-start.js`,
+  `.claude/ralph.config.json` and `.claude/ralph.md` on that branch are the same
+  versions `master` has. If they are not, it refuses and tells you to merge `master` in
+  first.
+
+  ```
+  | resuming on feature/user-profile-phase-4: its 3 orchestrator files match master
+    mid-issue: leaving feature/user-profile-phase-4 where the checkpoint left it, no trunk merge
+  ```
+
+  The trunk merge is skipped on purpose while an issue is open: it would move `HEAD` out
+  from under the commit the checkpoint measured that issue's diff from, and the resume
+  would then refuse itself. The merges happen at the start of the next phase.
+- **A stale checkpoint does not hold a phase back.** One that left no commit and has
+  nothing in the tree is not contradicted by a moved `HEAD` — it is just older than the
+  branch — so the loop says so, drops it and starts the phase normally.
 - **A checkpoint whose work has been thrown away is noticed.** If you read the leftovers
   and discard them, the next run finds nothing in the tree and implements the issue again
   rather than reviewing an empty diff.


### PR DESCRIPTION
The defect the canary exposed at the end of PR #79: an interrupted issue could not actually be resumed.

## The deadlock

The checkpoint and the startup guard were incompatible in the ordinary case:

- an interrupted issue's work is **uncommitted, on the phase branch**;
- the loop may only start **from the trunk**;
- git refuses to carry a file the trunk does not have back to the trunk.

That last one is every issue that adds a file, which is most of them. The canary stood at `ISSUE_REVIEW` with the work in the tree — precisely the case the checkpoint exists for — and the only way back to `master` was `git stash`, which discards exactly what the checkpoint was protecting.

```
error: Your local changes to the following files would be overwritten by checkout:
	apps/api/test/users-avatar.e2e-spec.ts
```

## What changes

**A run may start from the branch its own checkpoint names.** The branch name was only ever a proxy for the real question — *is this the same loop the trunk would run?* — so that question is now asked directly: `.claude/ralph-start.js`, `.claude/ralph.config.json` and `.claude/ralph.md` must be the versions the trunk has. A branch carrying its own copy is still refused, and told to merge the trunk in first.

```
| resuming on feature/user-profile-phase-4: its 3 orchestrator files match master
  mid-issue: leaving feature/user-profile-phase-4 where the checkpoint left it, no trunk merge
```

**The trunk merges are skipped while an issue is open.** They move `HEAD` out from under the commit the checkpoint measured that issue's diff from, so the resume then refused itself — a run that had done nothing wrong. Those merges belong to the start of a phase; the next phase picks them up. This was the second canary stop.

**A checkpoint with nothing at stake no longer pins anything.** One that left no commit and has nothing in the tree is not contradicted by a moved `HEAD` — it is simply older than the branch — so it is dropped with a line in the log and the phase starts normally.

## Verification

123 tests, all passing. Six cover the branch decision, three drive `runPhase` through the fake runtime and assert the trunk merge happens exactly when it should — the fake had to learn `rev-parse --verify` and `merge-base` first, because answering "yes" to every ref made a phase read as already merged and silently skipped the code under test.

Then the same guard was evaluated against **real git**, not a model of it, on three branches:

| Branch | Drift vs `origin/master` | Result |
| --- | --- | --- |
| `feature/user-profile-phase-4` (stale orchestrator) | `.claude/ralph-start.js` | refused, told to merge `master` |
| a branch cut from `origin/master` | none | allowed to start |
| same branch, checkpoint naming a different branch | none | refused |

No model session was spent on any of this.

## Not verified

The full resume has not been exercised end to end against a live interruption — that needs a real run to be interrupted at the right moment. The parts are covered separately; the first real interruption is still the thing that tests them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
