### PR TITLE
fix(ralph): do not re-implement an issue the loop just closed

### DIFF
--- a/.claude/ralph-start.js
+++ b/.claude/ralph-start.js
@@ -1704,6 +1704,21 @@ async function settleSession(st, cfg, opts, what, budget) {
  * honour it: the retry inside drainIssues after a rate limit, and the next process.
  */
 async function runIssue(phase, cfg, opts, budget, issue) {
+  // One authoritative read before anything is spent. The list an issue came from can be
+  // seconds behind - GitHub handed this loop back an issue it had just closed itself -
+  // and an issue somebody closed by hand needs no session at all.
+  if (issueState(issue) === 'CLOSED') {
+    const saved = stateFor(cfg, phase);
+    const mine = saved && saved.issue === issue.number ? saved : null;
+    if (mine) clearState();
+    return {
+      status: 'closed',
+      note: mine && mine.commitSha
+        ? `already committed as ${mine.commitSha.slice(0, 8)} and closed`
+        : 'already closed on GitHub',
+    };
+  }
+
   const ctx = prepareIssue(phase, cfg, budget, issue);
 
   const mark = (stage, extra) => {
@@ -1754,14 +1769,10 @@ async function runIssue(phase, cfg, opts, budget, issue) {
 
   // Work that is already committed is never done twice. GitHub is asked first: an issue
   // somebody closed by hand while the loop was down needs no work at all.
+  // An issue already closed on GitHub never gets this far - the check at the top of this
+  // function returns before anything is read or spent - so what is left here is a commit
+  // that exists with the issue still open.
   if (resume && resume.commitSha) {
-    if (issueState(issue) === 'CLOSED') {
-      clearState();
-      return {
-        status: 'closed',
-        note: `already committed as ${resume.commitSha.slice(0, 8)} and closed`,
-      };
-    }
     log(
       `~ resuming issue #${issue.number} at CLOSE_ISSUE - it is committed as ${resume.commitSha.slice(0, 8)}, only the close is left`,
     );
@@ -1956,7 +1967,13 @@ async function runIssue(phase, cfg, opts, budget, issue) {
 /** Runs the issue pipeline until the milestone has no open issues left. */
 async function drainIssues(phase, cfg, opts, budget) {
   const attempts = budget.attempts;
-  let open = openIssues(phase.milestone);
+  // GitHub's issue list lags behind a close by seconds. The loop closed #42, asked for
+  // the open issues, was handed #42 again, and spent two sessions re-implementing work
+  // that was already committed - each of which correctly changed nothing, so the issue
+  // then read as one that could not be implemented at all. What this run has closed and
+  // verified is not something to ask GitHub about twice.
+  const settled = () => openIssues(phase.milestone).filter((i) => !budget.done.has(i.number));
+  let open = settled();
 
   while (open.length > 0) {
     checkInterrupt();
@@ -2000,11 +2017,13 @@ async function drainIssues(phase, cfg, opts, budget) {
       attempts.set(issue.number, 0);
       budget.baseSha.delete(issue.number);
       budget.issuesClosed++;
+      budget.done.add(issue.number);
       log(`+ issue #${issue.number} closed . ${summary}`);
       if (overBudget) throw budgetStop();
-      // GitHub stays the source of truth even though the orchestrator did the closing:
-      // re-reading also picks up an issue somebody closed by hand meanwhile.
-      open = openIssues(phase.milestone);
+      // GitHub stays the source of truth for what is left - re-reading picks up an issue
+      // somebody closed by hand, or one the phase review filed - minus what this run has
+      // already finished, which no list is going to tell it about sooner than it knows.
+      open = settled();
       continue;
     }
 
@@ -2155,6 +2174,7 @@ async function runPhase(phase, cfg, opts, base, budget) {
   budget.attempts = new Map();
   budget.limitAborts = new Map();
   budget.baseSha = new Map();
+  if (!budget.done) budget.done = new Set();
   budget.phaseTokens = 0;
 
   // A checkpoint for this phase carries the anchor its issue was measured from. Seeding
@@ -2504,6 +2524,9 @@ async function main() {
     limitAborts: new Map(),
     baseSha: new Map(),
     rateLimitWaits: 0,
+    // Issues this run closed and verified. A list that has not caught up yet does not
+    // get to reopen the question.
+    done: new Set(),
   };
   const startedAt = Date.now();
   let executed = 0;

--- a/.claude/tests/budget.test.js
+++ b/.claude/tests/budget.test.js
@@ -30,6 +30,7 @@ const newBudget = () => ({
   attempts: new Map(),
   limitAborts: new Map(),
   baseSha: new Map(),
+  done: new Set(),
 });
 
 /**
@@ -128,4 +129,48 @@ test('the test harness never writes to the real stats file', async () => {
   assert.equal(after, before, 'the run baseline is untouched');
   assert.ok(statsFile.includes('ralph-test-'), 'stats went to a temp directory');
   assert.deepEqual(ralph.paths.stats, '.claude/ralph.stats.jsonl', 'paths restored');
+});
+
+test('a list that has not caught up does not hand the same issue back', async () => {
+  // What phase 4 actually did: the loop closed #41, asked GitHub for the open issues,
+  // was handed #41 again seconds later, and spent two more sessions re-implementing work
+  // that was already committed. Each correctly changed nothing, so the issue then read
+  // as one that could not be implemented at all and the run stopped.
+  const { error, budget, repo } = await drainOne({
+    cfg: config(),
+    repo: { listLag: true },
+  });
+
+  assert.equal(error, null, error && error.message);
+  assert.equal(budget.issuesClosed, 1);
+  assert.equal(repo.commits.length, 1, 'committed once, not three times');
+  assert.deepEqual([...budget.done], [41]);
+  // The list still says it is open; the loop knows better because it closed it itself.
+  assert.equal(repo.open.length, 1);
+});
+
+test('an issue GitHub already reports closed costs no session at all', async () => {
+  const spawnSync = fakeRepo({ listLag: true });
+  spawnSync.state.closed.add(41);
+  const paths = withTempPaths(ralph);
+  const loud = quiet();
+  const spawn = fakeSpawn({ fixtures: ['session-impl'] });
+  const restore = withFakes(ralph, { spawnSync, spawn });
+  try {
+    const result = await ralph.runIssue(
+      { index: 4, milestone: 'Phase 4: Avatar streaming', branch: 'feature/user-profile-phase-4' },
+      config(),
+      { issues: null, stopOnLimit: false },
+      newBudget(),
+      { number: 41, title: 'Stream the avatar' },
+    );
+    assert.equal(result.status, 'closed');
+    assert.match(result.note, /already closed on GitHub/);
+    assert.equal(spawn.calls.length, 0, 'no session was started');
+    assert.equal(spawnSync.state.commits.length, 0);
+  } finally {
+    restore();
+    loud();
+    paths.restore();
+  }
 });

--- a/.claude/tests/helpers/fake-repo.js
+++ b/.claude/tests/helpers/fake-repo.js
@@ -41,6 +41,10 @@ function fakeRepo(opts = {}) {
     gateRuns: [],
     merges: [],
     calls: [],
+    closed: new Set(),
+    // Keeps a closed issue on the open list, the way GitHub's own list does for a few
+    // seconds after a close.
+    listLag: !!opts.listLag,
     // Which refs exist, matched as substrings: the phase branch does, its tag does not,
     // so a phase reads as unfinished rather than already merged.
     refs: opts.refs || ['refs/heads/'],
@@ -85,12 +89,14 @@ function fakeRepo(opts = {}) {
     if (file === 'gh') {
       if (line.includes('issue list')) return ok(JSON.stringify(state.open));
       if (line.includes('issue view') && line.includes('--json state')) {
-        // Still on the open list means still open on GitHub. A resume asks this before
-        // it closes anything, so answering CLOSED unconditionally would hide the very
-        // path being tested.
+        // The authoritative single-issue read, which is not the same thing as the list:
+        // GitHub's list lags behind a close by seconds, and `listLag` reproduces that.
         const number = Number(argv[2]);
-        const open = state.open.some((i) => i.number === number);
-        return ok(JSON.stringify({ state: open ? 'OPEN' : state.stateAfterClose }));
+        return ok(
+          JSON.stringify({
+            state: state.closed.has(number) ? state.stateAfterClose : 'OPEN',
+          }),
+        );
       }
       if (line.includes('issue view')) {
         return ok(
@@ -103,7 +109,8 @@ function fakeRepo(opts = {}) {
       if (line.includes('issue close')) {
         if (state.closeFails) return bad('HTTP 403: Resource not accessible');
         const number = Number(argv[2]);
-        state.open = state.open.filter((i) => i.number !== number);
+        state.closed.add(number);
+        if (!state.listLag) state.open = state.open.filter((i) => i.number !== number);
         return ok();
       }
       return ok('[]');

--- a/.claude/tests/issue-pipeline.test.js
+++ b/.claude/tests/issue-pipeline.test.js
@@ -36,6 +36,7 @@ const newBudget = () => ({
   attempts: new Map(),
   limitAborts: new Map(),
   baseSha: new Map(),
+  done: new Set(),
 });
 
 /**

--- a/.claude/tests/state.test.js
+++ b/.claude/tests/state.test.js
@@ -46,6 +46,7 @@ const newBudget = () => ({
   limitAborts: new Map(),
   baseSha: new Map(),
   rateLimitWaits: 0,
+  done: new Set(),
 });
 
 /**
@@ -345,7 +346,10 @@ test('an issue closed by hand while the loop was down needs no work at all', asy
     await l.run({ fixtures: ['session-impl', 'session-review-approved'] });
     assert.equal(l.state().stage, 'CLOSE_ISSUE');
 
-    l.repo.open = []; // closed on GitHub by a human
+    // Closed on GitHub by a human. The list and the single-issue read are separate
+    // things in the fake because they are separate things in GitHub - the list lags.
+    l.repo.closed.add(41);
+    l.repo.open = [];
     const second = await l.run({ fixtures: ['session-impl'] });
 
     assert.equal(second.spawn.calls.length, 0);


### PR DESCRIPTION
The first full phase run stopped after one issue. It had done that issue correctly.

```
+ issue #42 closed . $1.25 . 4m02s . 1.18M gross in . committed 6cff090d
> issue #42 "Add GetAvatarQuery + handler" . attempt 1/2 . sonnet . maxTurns 100
- issue #42 still open . $0.47 . the session changed nothing
> issue #42 "Add GetAvatarQuery + handler" . attempt 2/2 . sonnet . maxTurns 100
- issue #42 still open . $0.36 . the session changed nothing
!! STOPPED: issue #42 is not progressing after 2 attempts
```

## Why

GitHub's issue list lags behind a close by seconds. The loop closed #42, committed it, **verified the closure through the single-issue endpoint**, then asked for the milestone's open issues — and was handed #42 back. It re-ran the implementation twice on work that was already committed. Both sessions correctly changed nothing, which the loop reads as an issue that cannot be implemented, so the phase stopped. $0.83 spent on nothing, and three issues never attempted.

Worth noting what did *not* fail: the issue itself was implemented, gated, reviewed, committed and closed properly, and `gh issue view` reported `CLOSED` throughout. Only the list disagreed.

## Two guards

**What this run has closed, it remembers.** Issues closed and verified are filtered out of every later list — no list is going to tell the loop about that sooner than it already knows.

**Nothing is spent before the issue's own state is read.** The single-issue endpoint does not lag the way the list does, so an issue closed by hand, or by a list that has not caught up, costs no session at all.

The resume path that closed an already-closed issue goes with them: unreachable now, and a second way of asking the same question.

## Tests

125, all passing. Two are new, and the fake had to learn that a list and a single-issue read are different things before either could reproduce the failure — the same fake previously answered both from one array, which is exactly why no test saw this coming.

Both new tests were run against the code with the guards disabled and both fail there, so they are testing the fix rather than agreeing with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
