### PR TITLE
fix(ralph): log what a review blocked on, not only that it blocked

### DIFF
--- a/.claude/ralph-start.js
+++ b/.claude/ralph-start.js
@@ -1571,6 +1571,56 @@ function runIssueGate(cfg, files) {
   return null;
 }
 
+/**
+ * One log line per finding of a BLOCKED review.
+ *
+ * The verdict alone said that something blocked and never what. The findings went into
+ * the repair session's prompt and nowhere else, so afterwards there was no way to tell
+ * a reviewer that blocked for a good reason from one that blocked for a bad one - and
+ * a reviewer nobody can audit is the rubber stamp this pipeline replaced.
+ *
+ * Parsed against the shape `issueReviewPrompt` asks for. A reply that ignores that
+ * shape still reaches the log, in the raw: a reviewer that will not follow the format
+ * is itself the thing worth seeing.
+ */
+function reviewFindings(text) {
+  const raw = String(text || '').trim();
+  if (!raw) return [];
+  const clip = (s, n) => (s.length > n ? `${s.slice(0, n - 1)}…` : s);
+
+  const entries = [];
+  let cur = null;
+  for (const line of raw.split('\n')) {
+    if (/^[ \t]*-[ \t]+\S/.test(line)) {
+      if (cur) entries.push(cur);
+      cur = {};
+    }
+    const kv = line.match(
+      /^[ \t]*(?:-[ \t]+)?(id|severity|file|line|problem):[ \t]*(.+?)[ \t]*$/i,
+    );
+    if (cur && kv) cur[kv[1].toLowerCase()] = kv[2];
+  }
+  if (cur) entries.push(cur);
+
+  const named = entries.filter((e) => e.problem);
+  if (named.length > 0) {
+    return named.map((e) => {
+      const where = e.file ? `${e.file}${e.line ? `:${e.line}` : ''}` : '';
+      const head = [e.id, e.severity && `[${e.severity}]`, where]
+        .filter(Boolean)
+        .join(' ');
+      return clip(head ? `${head} - ${e.problem}` : e.problem, 160);
+    });
+  }
+
+  return raw
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !/^\**VERDICT\b/i.test(l))
+    .slice(0, 8)
+    .map((l) => clip(l, 160));
+}
+
 /** The `COMMIT: <subject>` line a session ends with, if it wrote one. */
 function suggestedCommit(text) {
   const lines = String(text || '').match(/^[ \t]*COMMIT:[ \t]*(.+)$/gim);
@@ -1941,6 +1991,7 @@ async function runIssue(phase, cfg, opts, budget, issue) {
         return { status: 'closed', note: `committed ${commitCloseOut().slice(0, 8)}` };
       }
       findings = rv.resultText.trim();
+      for (const line of reviewFindings(findings)) log(`    ${line}`);
     }
 
     if (round > cfg.maxIssueRepairs) {
@@ -2629,6 +2680,7 @@ module.exports = {
   tailOf,
   recordStats,
   readVerdict,
+  reviewFindings,
   sessionOutcome,
   abortedByRateLimit,
   deniedTools,

--- a/.claude/tests/helpers.test.js
+++ b/.claude/tests/helpers.test.js
@@ -240,3 +240,57 @@ test('a real batch shim actually runs through shimSpawnArgs', {
   assert.equal(r.status, 0, `pnpm did not run: ${(r.stdout || '') + (r.stderr || '')}`);
   assert.match(r.stdout.trim(), /^\d+\.\d+\.\d+/, r.stdout);
 });
+
+test('reviewFindings turns a BLOCKED reply into one log line per finding', () => {
+  // Issue #45 was blocked in phase 4 and the log kept only `review: BLOCKED`. What was
+  // wrong with the code went into the repair prompt and was then unrecoverable, so
+  // nobody could tell an honest block from a bad one after the fact.
+  const reply = [
+    'FINDINGS:',
+    '- id: R1',
+    '  severity: blocking',
+    '  file: apps/api/src/avatar/avatar.service.ts',
+    '  line: 88',
+    '  problem: the upload path never checks that the profile belongs to the caller',
+    '  reason: any authenticated user can overwrite another profile picture',
+    '  required_fix: compare profile.userId with the request user before writing',
+    '- id: R2',
+    '  severity: blocking',
+    '  file: apps/api/test/avatar.spec.ts',
+    '  problem: no test covers a rejected content type',
+    '  reason: the guard added for this issue is unverified',
+    '  required_fix: add a case posting image/svg+xml',
+    '',
+    'VERDICT: BLOCKED',
+  ].join('\n');
+
+  assert.deepEqual(ralph.reviewFindings(reply), [
+    'R1 [blocking] apps/api/src/avatar/avatar.service.ts:88 - the upload path never ' +
+      'checks that the profile belongs to the caller',
+    'R2 [blocking] apps/api/test/avatar.spec.ts - no test covers a rejected content type',
+  ]);
+});
+
+test('reviewFindings still logs a reply that ignores the format', () => {
+  // A reviewer that will not follow the shape is itself worth seeing, so the fallback
+  // is the reply rather than silence. The verdict line carries nothing new.
+  const lines = ralph.reviewFindings(
+    'The migration drops the column before the backfill runs.\n\nVERDICT: BLOCKED',
+  );
+  assert.deepEqual(lines, ['The migration drops the column before the backfill runs.']);
+  assert.deepEqual(ralph.reviewFindings('   '), []);
+});
+
+test('reviewFindings does not invent findings out of an ordinary bullet list', () => {
+  const lines = ralph.reviewFindings(
+    ['I checked:', '- the guard', '- the tests', '', 'VERDICT: BLOCKED'].join('\n'),
+  );
+  assert.deepEqual(lines, ['I checked:', '- the guard', '- the tests']);
+});
+
+test('reviewFindings clips a finding that would flood the log', () => {
+  const reply = `- id: R1\n  problem: ${'x'.repeat(400)}`;
+  const [only] = ralph.reviewFindings(reply);
+  assert.ok(only.length <= 160, `${only.length} chars`);
+  assert.ok(only.startsWith('R1 - xxx'), only);
+});

--- a/.claude/tests/helpers/fake-repo.js
+++ b/.claude/tests/helpers/fake-repo.js
@@ -150,6 +150,7 @@ function withTempPaths(ralph) {
   ralph.paths.state = path.join(dir, 'ralph.state.json');
   return {
     dir,
+    log: ralph.paths.log,
     stats: ralph.paths.stats,
     state: ralph.paths.state,
     restore() {

--- a/.claude/tests/issue-pipeline.test.js
+++ b/.claude/tests/issue-pipeline.test.js
@@ -69,7 +69,8 @@ async function runOne({ fixtures, repo = {}, cfg = {}, exitCode = 0, opts = {} }
       .split('\n')
       .filter(Boolean)
       .map((line) => JSON.parse(line));
-    return { result, error, budget, spawn, repo: spawnSync.state, statsRows };
+    const logText = fs.existsSync(paths.log) ? fs.readFileSync(paths.log, 'utf8') : '';
+    return { result, error, budget, spawn, repo: spawnSync.state, statsRows, logText };
   } finally {
     restore();
     loud();
@@ -229,6 +230,23 @@ test('a blocking verdict sends the work to repair and then reviews it again', as
   assert.match(prompts(spawn)[2], /Fix exactly what is above/);
   assert.equal(repo.gateRuns.length, 4, 'the gate ran again after the repair');
   assert.equal(repo.commits.length, 1, 'and only the approved state was committed');
+});
+
+test('what the reviewer blocked on reaches the log, not only the repair prompt', async () => {
+  // Issue #45 of phase 4 was blocked and repaired, and the log kept nothing but
+  // `review: BLOCKED`. What was wrong lived only inside the repair session's prompt, so
+  // afterwards there was no way to judge whether the block was justified - and a
+  // reviewer nobody can audit is the rubber stamp this pipeline was built to replace.
+  const { logText } = await runOne({
+    fixtures: ['session-impl', 'session-review-blocked', 'session-impl', 'session-review-approved'],
+  });
+
+  assert.match(logText, /review: BLOCKED/);
+  assert.match(
+    logText,
+    /R1 \[blocking\] apps\/api\/src\/meetings\/avatar\.controller\.ts:42 - the ownership check is missing/,
+    logText,
+  );
 });
 
 test('a failing gate is repaired before any reviewer is paid for', async () => {

--- a/docs/ralph-loop-cost/work-order-2-issue-review.md
+++ b/docs/ralph-loop-cost/work-order-2-issue-review.md
@@ -231,15 +231,21 @@ Only after explicit approval, and only after the fake end-to-end test passes: on
       which it never used.
 - [x] No scratch diff files are written into the repository — no session computes a diff for
       review any more.
-- [x] Median cost per issue is at or below $1.50. **Measured on the canary: $1.44** for issue
-      #41 — $0.93 implementation plus $0.51 review — against a $2.02 baseline, a 29% drop.
-      One issue is one sample, and this one was a test-only change of 126 lines in a single
-      file; the median over a whole phase will move. The figure also excludes the phase
-      review, which the canary did not reach (about $0.27 per issue when amortised).
-- [ ] **No drop in blocking defects found — not established.** The reviewer approved issue
-      #41 and filed nothing, which is one sample and proves nothing either way. The old
-      self-review's findings were never recorded anywhere, so there is no baseline number to
-      compare against; the only honest comparison is over a full phase.
+- [x] Median cost per issue is at or below $1.50. **Measured over phase 4: $1.25**
+      ($0.79, $0.96, $1.25, $1.44, $2.55 across issues #41–#45) against a $2.02
+      baseline — a 38% drop, mean $1.40. Those are the runs no orchestrator defect
+      interfered with; the raw file totals read $2.08 median because the debugging of
+      the three canary defects is charged to #41 ($6.06 over ten sessions) and #42
+      ($2.08). The phase review adds $1.57 over five issues, about $0.31 each.
+- [ ] **No drop in blocking defects found — still not established, but no longer blind.**
+      Over phase 4 the reviewer blocked one issue of five (#45: $0.54 to find it, $0.15
+      to repair, $0.72 to re-review) and approved it only after the repair, which is the
+      first evidence it is not a rubber stamp. The Opus phase review then approved and
+      filed five non-blocking issues (#82–#86), so nothing blocking survived to the
+      backstop. What is still missing is the comparison itself: the old self-review never
+      recorded a finding anywhere, so there is no baseline number, and one blocked issue
+      in five is a rate, not a proof. Since 0de014f the findings reach `ralph.log`, so
+      later phases accumulate the record this criterion needs.
 
 ### What the canary actually proved
 
@@ -263,15 +269,27 @@ than the whole `master...HEAD` diff; the orchestrator committed with the session
 conventional subject, closed the issue, verified it against GitHub and only then cleared the
 checkpoint.
 
+### What the first full phase added
+
+Phase 4 ran end to end on 2026-08-20: five issues, `00ae5b4` merged into
+`feature/user-profile` and tagged `ralph/user-profile/phase-4`, exit code 0 in 24m13s for
+$5.87 including the phase review. Three things it proved that the canary could not:
+
+1. **The reviewer blocks.** Issue #45 came back `BLOCKED`, was repaired and only then
+   approved. One issue in five, and the only round the pipeline paid for twice.
+2. **A stale checkpoint is dropped rather than obeyed.** The run opened with
+   `checkpoint for issue #42 at IMPLEMENT has nothing left in the tree, starting the phase
+   normally` — the resume guard's own path, exercised live for the first time.
+3. **A stale issue list is survivable.** GitHub handed back #42 seconds after it was
+   closed; `budget.done` plus the pre-flight state read meant no session was spent on it.
+
+It also found the fourth defect: the reviewer's findings never reached the log, so a block
+could not be judged after the fact. Fixed in `0de014f`.
+
 ### Still open
 
-**Resume is unreachable whenever an issue adds a file the trunk does not have.** The
-checkpoint stood at `ISSUE_REVIEW` with the work in the tree — the case it exists for — but
-the loop must start from the default branch, and `git switch master` refuses to carry an
-uncommitted new file that master does not know. The only way back is to stash, which throws
-away exactly what the checkpoint was protecting. New files are the common case, not an edge
-one. This belongs to WO-3 and must be fixed before a real phase run: interruptions are
-certain.
+The resume problem this section used to describe — `git switch master` refusing to carry an
+issue's new file back to the trunk — was fixed in WO-3 and exercised in phase 4.
 
 ### Deviations to know about
 

--- a/docs/ralph-loop-rework/usage.md
+++ b/docs/ralph-loop-rework/usage.md
@@ -112,6 +112,19 @@ A gate step that fails, or a review that returns `BLOCKED`, prints a `~ repair 1
 and the issue goes round again. Nothing is committed until the gate is green **and** the
 reviewer said `APPROVED`.
 
+Both say why in the log, one indented line each:
+
+```
+[15:02:11]   review: BLOCKED . $0.54 . 16 req . 2m38s
+[15:02:11]     R1 [blocking] apps/api/src/users/avatar.controller.ts:42 - the ownership check is missing
+[15:02:11] ~ repair 1/2 for issue #45
+```
+
+That is the only record of what the reviewer objected to - the findings otherwise go
+to the repair session and nowhere else, leaving no way to tell a justified block from
+a bad one afterwards. A reviewer that ignores the reply format has its reply logged
+raw instead, which is itself worth seeing.
+
 If a session goes more than two minutes without an event you get a warning. If the
 silence drags on, the session is killed and retried.
 


### PR DESCRIPTION
Phase 4 blocked issue #45, repaired it and approved it, and the log kept exactly one line about it:

```
[20:21:43]   review: BLOCKED . $0.54 . 16 req . 2m38s
```

The findings themselves went into the repair session's prompt and nowhere else. After the run there was no way to tell whether the reviewer had blocked for a good reason — which is the same blind spot the gate had before `80158f0`, and it matters more here: a reviewer nobody can audit is the rubber stamp this pipeline was built to replace.

## What changes

`reviewFindings` parses the shape `issueReviewPrompt` asks for and prints one indented line per finding under the verdict:

```
[20:21:43]   review: BLOCKED . $0.54 . 16 req . 2m38s
[20:21:43]     R1 [blocking] apps/api/src/users/avatar.controller.ts:42 - the ownership check is missing
[20:21:43] ~ repair 1/2 for issue #45
```

A reply that ignores the format is logged raw rather than dropped — a reviewer that will not follow the shape is itself worth seeing. An ordinary bullet list is not mistaken for findings, and a long finding is clipped so one review cannot flood the log.

## Verification

- 130 tests pass (`pnpm test:ralph`), 4 new unit tests plus one pipeline test.
- The pipeline test was run against the unfixed orchestrator first and fails there (`28 pass / 1 fail`), so it tests the fix rather than agreeing with it.
- No behaviour outside the log changes: the verdict, the repair prompt and the commit decision are untouched.

The second commit records what phase 4 actually measured against WO-2's definition of done: $1.25 median per issue against the $2.02 baseline, and why the raw stats file reads $2.08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
