### PR TITLE
feat(api): add Claude Agent SDK policy hooks for the meeting agent

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -41,11 +41,21 @@ MEETING_ALLOWED_TOOLS`), so it can look up/record `Task` rows and write the summ
   (Postgres `pg_trgm`). Reached from `summarize`'s agent run via the `meeting` MCP tools.
 - `src/claude-agent/` — `ClaudeAgentService`, a thin wrapper around the Claude Agent SDK for a
   single-turn prompt/response call; `ask` resolves a `ClaudeAgentReply` (`text` plus, when the
-  caller set `options.outputFormat`, the schema-validated `structuredOutput`)
+  caller set `options.outputFormat`, the schema-validated `structuredOutput`). `ClaudeAgentModule`'s
+  `runClaudeAgent` always overwrites `options.hooks` with a fresh `createMeetingHooks()` call
+  (`../hooks`) before calling `query()` — see Invariants — and, once the run's `result` message
+  arrives, logs `total_cost_usd`/`usage` (input/output tokens) tagged with the optional `meetingId`
+  `ask`/`ClaudeAgentRunner` take purely for that log line.
 - `src/meeting-tools.ts` — `createMeetingToolsServer`, wrapping `TaskService`/`MeetingSummaryService`
   (via structural interfaces, not the concrete classes, to avoid a circular import with
   `meeting-summary/`) as a `meeting` SDK MCP server (`find_tasks`/`upsert_task`/`update_meeting`).
   Wired into `MeetingSummaryService.summarize`'s `options.mcpServers`.
+- `src/hooks.ts` — `createMeetingHooks`, the Claude Agent SDK `HookCallback`s guarding every
+  `ClaudeAgentService.ask` run (wired into `options.hooks` by `runClaudeAgent`, not by callers —
+  see `src/claude-agent/` above): `preToolUseGuard` denies `upsert_task` calls with a too-short
+  title, `createCallBudgetHook` caps total tool calls per run (`DEFAULT_TOOL_CALL_BUDGET`),
+  `auditLog` logs every completed tool call via Nest `Logger` — the sole place tool calls are
+  logged; `meeting-tools.ts`'s own handlers don't log.
 
 ## CQRS pattern
 
@@ -119,6 +129,14 @@ The reasoning behind them is in `docs/architecture/api.md`.
   Jest's CommonJS test VM, on **every** script that can reach that code path, not just the unit
   `test` script — `test:e2e` runs it too (`MeetingSummaryService.summarize`, exercised by any e2e
   spec that uploads a recording), so it carries the same flag.
+- **`runClaudeAgent` (`claude-agent.module.ts`) always overwrites `options.hooks` with a fresh
+  `createMeetingHooks()` call** (`hooks.ts`), built inside the function body on every invocation —
+  never hoisted to module scope — so `createCallBudgetHook`'s tool-call counter starts at zero for
+  each run instead of being shared (and silently exhausted) across unrelated meetings. Any
+  `options.hooks` a caller passes in is discarded without a warning; there is currently only one
+  caller (`MeetingSummaryService.summarize`), which doesn't set `hooks` itself for exactly this
+  reason. If a second, non-meeting caller of `ClaudeAgentService.ask` is ever added, this needs to
+  become configurable instead of hardcoded.
 - **`update_meeting` (a `meeting-tools.ts` tool) always settles `MeetingSummary.status` to `READY`**
   — when the agent calls it mid-fold, on a meeting with more than one recording still
   transcribing, the row is briefly `READY` until `MeetingSummaryService.generateForMeeting`'s own

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -54,8 +54,10 @@ MEETING_ALLOWED_TOOLS`), so it can look up/record `Task` rows and write the summ
   `ClaudeAgentService.ask` run (wired into `options.hooks` by `runClaudeAgent`, not by callers —
   see `src/claude-agent/` above): `preToolUseGuard` denies `upsert_task` calls with a too-short
   title, `createCallBudgetHook` caps total tool calls per run (`DEFAULT_TOOL_CALL_BUDGET`),
-  `auditLog` logs every completed tool call via Nest `Logger` — the sole place tool calls are
-  logged; `meeting-tools.ts`'s own handlers don't log.
+  `auditLog` logs every completed or failed tool call (`PostToolUse` and `PostToolUseFailure` —
+  a thrown handler is a separate SDK event from a normal return) via Nest `Logger`, at `warn` for a
+  thrown exception or an MCP `{ isError: true }` result and `log` otherwise — the sole place tool
+  calls are logged; `meeting-tools.ts`'s own handlers don't log.
 
 ## CQRS pattern
 

--- a/apps/api/src/claude-agent/claude-agent-runner.ts
+++ b/apps/api/src/claude-agent/claude-agent-runner.ts
@@ -13,10 +13,16 @@ export interface ClaudeAgentReply {
   structuredOutput: unknown;
 }
 
-/** A function that sends a prompt to Claude via the Claude Agent SDK and resolves with its reply. */
+/**
+ * A function that sends a prompt to Claude via the Claude Agent SDK and resolves with its reply.
+ *
+ * `meetingId` is optional and used only to tag the run's cost/usage log line (see
+ * `claude-agent.module.ts`'s `runClaudeAgent`) — it plays no part in the SDK call itself.
+ */
 export type ClaudeAgentRunner = (
   prompt: string,
   options: Options,
+  meetingId?: string,
 ) => Promise<ClaudeAgentReply>;
 
 /** DI token for the `ClaudeAgentRunner` in use — swapped for a stub in tests that don't need the real SDK subprocess. */

--- a/apps/api/src/claude-agent/claude-agent.module.spec.ts
+++ b/apps/api/src/claude-agent/claude-agent.module.spec.ts
@@ -1,0 +1,132 @@
+import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import type {
+  HookCallbackMatcher,
+  HookEvent,
+} from '@anthropic-ai/claude-agent-sdk';
+
+type CapturedOptions = {
+  hooks: Partial<Record<HookEvent, HookCallbackMatcher[]>>;
+} & Record<string, unknown>;
+
+interface QueryCall {
+  prompt: string;
+  options: CapturedOptions;
+}
+
+const mockQuery = jest.fn<unknown, [QueryCall]>();
+
+/**
+ * `runClaudeAgent` loads `@anthropic-ai/claude-agent-sdk` via a dynamic `import()` (it's ESM-only —
+ * see `claude-agent.module.ts`'s own doc comment). A plain `jest.mock()` doesn't intercept that
+ * under Jest's `--experimental-vm-modules` VM — it only patches `require`, so the real package
+ * would load and this suite would fire real Claude Agent SDK calls (do not remove this mock to
+ * "simplify" the setup). `jest.unstable_mockModule` is the API that does intercept a dynamic
+ * `import()`, registered before anything requires the module under test below.
+ */
+(
+  jest as unknown as {
+    unstable_mockModule: (id: string, factory: () => unknown) => void;
+  }
+).unstable_mockModule('@anthropic-ai/claude-agent-sdk', () => ({
+  query: (call: QueryCall) => mockQuery(call),
+}));
+
+function successResult(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'result',
+    subtype: 'success',
+    result: 'ok',
+    total_cost_usd: 0.0123,
+    usage: { input_tokens: 100, output_tokens: 50 },
+    structured_output: undefined,
+    ...overrides,
+  };
+}
+
+/**
+ * `require`, not a static/dynamic `import`, is what lets `claude-agent.module.ts` load *after*
+ * `unstable_mockModule` above has registered — a static import would be hoisted ahead of it, and a
+ * dynamic `import()` here would need an explicit `.js` extension to satisfy `moduleResolution:
+ * nodenext` (dynamic `import()` always resolves via the ESM algorithm, even from a CommonJS file)
+ * while ts-jest's runtime resolver only knows about the `.ts` source, so a `.js`-suffixed specifier
+ * fails at test time despite type-checking.
+ */
+/* eslint-disable @typescript-eslint/no-require-imports -- see doc comment above */
+const { ClaudeAgentModule } =
+  require('./claude-agent.module') as typeof import('./claude-agent.module');
+const { ClaudeAgentService } =
+  require('./claude-agent.service') as typeof import('./claude-agent.service');
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+describe('ClaudeAgentModule / runClaudeAgent', () => {
+  let service: import('./claude-agent.service').ClaudeAgentService;
+
+  beforeEach(async () => {
+    mockQuery.mockReset();
+    const moduleRef = await Test.createTestingModule({
+      imports: [ClaudeAgentModule],
+    }).compile();
+    service = moduleRef.get(ClaudeAgentService);
+  });
+
+  it('wires PreToolUse: [preToolUseGuard, callBudget] and PostToolUse: [auditLog] into options.hooks', async () => {
+    mockQuery.mockReturnValue([successResult()]);
+
+    await service.ask('prompt', { model: 'x', tools: [] }, 'meeting-1');
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [{ options }] = mockQuery.mock.calls[0];
+    expect(options.hooks.PreToolUse).toHaveLength(1);
+    expect(options.hooks.PreToolUse?.[0].hooks).toHaveLength(2);
+    expect(options.hooks.PostToolUse).toHaveLength(1);
+    expect(options.hooks.PostToolUse?.[0].hooks).toHaveLength(1);
+  });
+
+  it("logs total_cost_usd and usage tied to meetingId when a 'result' message arrives", async () => {
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    mockQuery.mockReturnValue([
+      successResult({
+        total_cost_usd: 0.042,
+        usage: { input_tokens: 111, output_tokens: 222 },
+      }),
+    ]);
+
+    await service.ask('prompt', { model: 'x', tools: [] }, 'meeting-42');
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /meetingId=meeting-42.*total_cost_usd=0\.042.*input_tokens=111.*output_tokens=222/,
+      ),
+    );
+
+    logSpy.mockRestore();
+  });
+
+  it('logs meetingId=unknown when no meetingId is given', async () => {
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    mockQuery.mockReturnValue([successResult()]);
+
+    await service.ask('prompt', { model: 'x', tools: [] });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('meetingId=unknown'),
+    );
+
+    logSpy.mockRestore();
+  });
+
+  it('gives each ask() call its own callBudget hook instance', async () => {
+    mockQuery.mockReturnValue([successResult()]);
+
+    await service.ask('prompt', { model: 'x', tools: [] }, 'meeting-1');
+    const [{ options: firstOptions }] = mockQuery.mock.calls[0];
+
+    await service.ask('prompt', { model: 'x', tools: [] }, 'meeting-2');
+    const [{ options: secondOptions }] = mockQuery.mock.calls[1];
+
+    expect(firstOptions.hooks.PreToolUse?.[0].hooks[1]).not.toBe(
+      secondOptions.hooks.PreToolUse?.[0].hooks[1],
+    );
+  });
+});

--- a/apps/api/src/claude-agent/claude-agent.module.spec.ts
+++ b/apps/api/src/claude-agent/claude-agent.module.spec.ts
@@ -70,7 +70,7 @@ describe('ClaudeAgentModule / runClaudeAgent', () => {
     service = moduleRef.get(ClaudeAgentService);
   });
 
-  it('wires PreToolUse: [preToolUseGuard, callBudget] and PostToolUse: [auditLog] into options.hooks', async () => {
+  it('wires PreToolUse: [preToolUseGuard, callBudget] and PostToolUse/PostToolUseFailure: [auditLog] into options.hooks', async () => {
     mockQuery.mockReturnValue([successResult()]);
 
     await service.ask('prompt', { model: 'x', tools: [] }, 'meeting-1');
@@ -81,6 +81,8 @@ describe('ClaudeAgentModule / runClaudeAgent', () => {
     expect(options.hooks.PreToolUse?.[0].hooks).toHaveLength(2);
     expect(options.hooks.PostToolUse).toHaveLength(1);
     expect(options.hooks.PostToolUse?.[0].hooks).toHaveLength(1);
+    expect(options.hooks.PostToolUseFailure).toHaveLength(1);
+    expect(options.hooks.PostToolUseFailure?.[0].hooks).toHaveLength(1);
   });
 
   it("logs total_cost_usd and usage tied to meetingId when a 'result' message arrives", async () => {

--- a/apps/api/src/claude-agent/claude-agent.module.ts
+++ b/apps/api/src/claude-agent/claude-agent.module.ts
@@ -1,7 +1,10 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
+import { createMeetingHooks } from '../hooks';
 import { CLAUDE_AGENT_RUNNER } from './claude-agent-runner';
 import type { ClaudeAgentRunner } from './claude-agent-runner';
 import { ClaudeAgentService } from './claude-agent.service';
+
+const logger = new Logger('ClaudeAgent');
 
 /**
  * Runs a single-turn Claude Agent SDK query and returns its final text.
@@ -13,17 +16,34 @@ import { ClaudeAgentService } from './claude-agent.service';
  * `test:cov` scripts) to support that dynamic import.
  *
  * `options` is forwarded to `query()` as-is — see `ClaudeAgentService` for why there is no
- * hardcoded `tools` default here. Authentication comes from `CLAUDE_CODE_OAUTH_TOKEN` in the
- * process environment: the SDK subprocess inherits `process.env` whenever `options.env` is
- * omitted.
+ * hardcoded `tools` default here — except `options.hooks`, which is always replaced with a fresh
+ * `createMeetingHooks()` call (`../hooks`): every caller today is `MeetingSummaryService`, so this
+ * hardcodes the `upsert_task` title guard, a per-run tool-call budget, and audit logging at the
+ * runner level rather than trusting each caller to opt in, and silently discards any `hooks` a
+ * caller passed in `options`. Calling `createMeetingHooks()` fresh on every `runClaudeAgent`
+ * invocation (never hoisted to module scope) is what keeps its call-budget counter scoped to this
+ * one run instead of leaking across unrelated meetings — see `createCallBudgetHook` in `../hooks`.
+ * Authentication comes from `CLAUDE_CODE_OAUTH_TOKEN` in the process environment: the SDK
+ * subprocess inherits `process.env` whenever `options.env` is omitted.
  */
-const runClaudeAgent: ClaudeAgentRunner = async (prompt, options) => {
+const runClaudeAgent: ClaudeAgentRunner = async (
+  prompt,
+  options,
+  meetingId,
+) => {
   const { query } = await import('@anthropic-ai/claude-agent-sdk');
 
-  for await (const message of query({ prompt, options })) {
+  const runOptions = { ...options, hooks: createMeetingHooks() };
+
+  for await (const message of query({ prompt, options: runOptions })) {
     if (message.type !== 'result') {
       continue;
     }
+
+    logger.log(
+      `meetingId=${meetingId ?? 'unknown'} total_cost_usd=${message.total_cost_usd} input_tokens=${message.usage.input_tokens} output_tokens=${message.usage.output_tokens}`,
+    );
+
     if (message.subtype === 'success') {
       return {
         text: message.result,

--- a/apps/api/src/claude-agent/claude-agent.service.spec.ts
+++ b/apps/api/src/claude-agent/claude-agent.service.spec.ts
@@ -10,15 +10,27 @@ const HAIKU_MODEL = 'claude-haiku-4-5';
 describe('ClaudeAgentService', () => {
   it('delegates to the injected ClaudeAgentRunner', async () => {
     const runClaudeAgent = jest
-      .fn<ReturnType<ClaudeAgentRunner>, [string, Options]>()
+      .fn<ReturnType<ClaudeAgentRunner>, [string, Options, string?]>()
       .mockResolvedValue({ text: 'pong', structuredOutput: undefined });
     const service = new ClaudeAgentService(runClaudeAgent);
     const options: Options = { model: HAIKU_MODEL, tools: [] };
 
     const result = await service.ask('ping', options);
 
-    expect(runClaudeAgent).toHaveBeenCalledWith('ping', options);
+    expect(runClaudeAgent).toHaveBeenCalledWith('ping', options, undefined);
     expect(result).toEqual({ text: 'pong', structuredOutput: undefined });
+  });
+
+  it('forwards an explicit meetingId to the injected ClaudeAgentRunner', async () => {
+    const runClaudeAgent = jest
+      .fn<ReturnType<ClaudeAgentRunner>, [string, Options, string?]>()
+      .mockResolvedValue({ text: 'pong', structuredOutput: undefined });
+    const service = new ClaudeAgentService(runClaudeAgent);
+    const options: Options = { model: HAIKU_MODEL, tools: [] };
+
+    await service.ask('ping', options, 'meeting-1');
+
+    expect(runClaudeAgent).toHaveBeenCalledWith('ping', options, 'meeting-1');
   });
 
   it('propagates a rejection from the injected ClaudeAgentRunner', async () => {

--- a/apps/api/src/claude-agent/claude-agent.service.ts
+++ b/apps/api/src/claude-agent/claude-agent.service.ts
@@ -12,10 +12,12 @@ import type {
  * `TranscriptionService`/`WhisperRunner`.
  *
  * `options` is passed through to the SDK almost verbatim (model, tools, permissionMode, cwd,
- * mcpServers, ...) — there is no safe default applied here. In particular, a caller that omits
- * `options.tools` gets whatever the SDK's own default is (the full built-in Claude Code toolset,
- * including Bash and file access, running on this server's filesystem). Callers that only want a
- * plain text reply must pass `tools: []` themselves.
+ * mcpServers, ...) — there is no safe default applied here, with one exception: `options.hooks` is
+ * always overwritten by `runClaudeAgent` with the meeting policy hooks from `../hooks` (see its own
+ * doc comment) rather than passed through, since every caller today is `MeetingSummaryService`. In
+ * particular, a caller that omits `options.tools` gets whatever the SDK's own default is (the full
+ * built-in Claude Code toolset, including Bash and file access, running on this server's
+ * filesystem). Callers that only want a plain text reply must pass `tools: []` themselves.
  */
 @Injectable()
 export class ClaudeAgentService {
@@ -24,7 +26,12 @@ export class ClaudeAgentService {
     private readonly runClaudeAgent: ClaudeAgentRunner,
   ) {}
 
-  ask(prompt: string, options: Options): Promise<ClaudeAgentReply> {
-    return this.runClaudeAgent(prompt, options);
+  /** `meetingId` — see `ClaudeAgentRunner` — is forwarded as-is; omit it outside a meeting run. */
+  ask(
+    prompt: string,
+    options: Options,
+    meetingId?: string,
+  ): Promise<ClaudeAgentReply> {
+    return this.runClaudeAgent(prompt, options, meetingId);
   }
 }

--- a/apps/api/src/hooks.spec.ts
+++ b/apps/api/src/hooks.spec.ts
@@ -1,0 +1,242 @@
+import { Logger } from '@nestjs/common';
+import type {
+  HookJSONOutput,
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+  SyncHookJSONOutput,
+} from '@anthropic-ai/claude-agent-sdk';
+import {
+  auditLog,
+  createCallBudgetHook,
+  createMeetingHooks,
+  DEFAULT_TOOL_CALL_BUDGET,
+  preToolUseGuard,
+} from './hooks';
+
+/** Every hook in this file only ever returns the sync shape — narrows past the `async` variant. */
+function sync(result: HookJSONOutput): SyncHookJSONOutput {
+  return result as SyncHookJSONOutput;
+}
+
+function preToolUseInput(
+  overrides: Partial<PreToolUseHookInput> = {},
+): PreToolUseHookInput {
+  return {
+    session_id: 'session-1',
+    transcript_path: '/tmp/transcript.jsonl',
+    cwd: '/tmp',
+    hook_event_name: 'PreToolUse',
+    tool_name: 'mcp__meeting__upsert_task',
+    tool_input: { title: 'Draft the roadmap doc' },
+    tool_use_id: 'tool-1',
+    ...overrides,
+  };
+}
+
+function postToolUseInput(
+  overrides: Partial<PostToolUseHookInput> = {},
+): PostToolUseHookInput {
+  return {
+    session_id: 'session-1',
+    transcript_path: '/tmp/transcript.jsonl',
+    cwd: '/tmp',
+    hook_event_name: 'PostToolUse',
+    tool_name: 'mcp__meeting__upsert_task',
+    tool_input: { title: 'Draft the roadmap doc' },
+    tool_response: { id: 'task-1' },
+    tool_use_id: 'tool-1',
+    ...overrides,
+  };
+}
+
+const hookOptions = { signal: new AbortController().signal };
+
+describe('preToolUseGuard', () => {
+  it('denies an upsert_task call with a missing title', async () => {
+    const result = await preToolUseGuard(
+      preToolUseInput({ tool_input: {} }),
+      'tool-1',
+      hookOptions,
+    );
+
+    expect(sync(result).hookSpecificOutput).toMatchObject({
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+    });
+  });
+
+  it('denies an upsert_task call with a title shorter than 3 characters', async () => {
+    const result = await preToolUseGuard(
+      preToolUseInput({ tool_input: { title: 'ab' } }),
+      'tool-1',
+      hookOptions,
+    );
+
+    expect(sync(result).hookSpecificOutput).toMatchObject({
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+    });
+  });
+
+  it('denies an upsert_task call whose title is only whitespace', async () => {
+    const result = await preToolUseGuard(
+      preToolUseInput({ tool_input: { title: '   ' } }),
+      'tool-1',
+      hookOptions,
+    );
+
+    expect(sync(result).hookSpecificOutput).toMatchObject({
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+    });
+  });
+
+  it('lets an upsert_task call with a valid title through', async () => {
+    const result = await preToolUseGuard(
+      preToolUseInput(),
+      'tool-1',
+      hookOptions,
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it('ignores calls to a different tool', async () => {
+    const result = await preToolUseGuard(
+      preToolUseInput({
+        tool_name: 'mcp__meeting__find_tasks',
+        tool_input: {},
+      }),
+      'tool-1',
+      hookOptions,
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it('ignores non-PreToolUse events', async () => {
+    const result = await preToolUseGuard(
+      postToolUseInput({ tool_input: {} }),
+      'tool-1',
+      hookOptions,
+    );
+
+    expect(result).toEqual({});
+  });
+});
+
+describe('createCallBudgetHook', () => {
+  it('allows calls up to the limit and denies once it is exceeded', async () => {
+    const hook = createCallBudgetHook(2);
+
+    const first = await hook(preToolUseInput(), 'tool-1', hookOptions);
+    const second = await hook(preToolUseInput(), 'tool-2', hookOptions);
+    const third = await hook(preToolUseInput(), 'tool-3', hookOptions);
+
+    expect(first).toEqual({});
+    expect(second).toEqual({});
+    expect(sync(third).hookSpecificOutput).toMatchObject({
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+    });
+  });
+
+  it('defaults to DEFAULT_TOOL_CALL_BUDGET when no limit is given', async () => {
+    const hook = createCallBudgetHook();
+
+    for (let i = 0; i < DEFAULT_TOOL_CALL_BUDGET; i++) {
+      const result = await hook(preToolUseInput(), `tool-${i}`, hookOptions);
+      expect(result).toEqual({});
+    }
+
+    const overBudget = await hook(preToolUseInput(), 'tool-over', hookOptions);
+    expect(sync(overBudget).hookSpecificOutput).toMatchObject({
+      permissionDecision: 'deny',
+    });
+  });
+
+  it('gives each call to the factory its own counter', async () => {
+    const first = createCallBudgetHook(1);
+    const second = createCallBudgetHook(1);
+
+    await first(preToolUseInput(), 'tool-1', hookOptions);
+    const secondResult = await second(preToolUseInput(), 'tool-2', hookOptions);
+
+    expect(secondResult).toEqual({});
+  });
+
+  it('ignores non-PreToolUse events', async () => {
+    const hook = createCallBudgetHook(0);
+
+    const result = await hook(postToolUseInput(), 'tool-1', hookOptions);
+
+    expect(result).toEqual({});
+  });
+});
+
+describe('auditLog', () => {
+  it('logs tool_name, tool_input and tool_response for a PostToolUse event', async () => {
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+
+    const result = await auditLog(
+      postToolUseInput({
+        tool_name: 'mcp__meeting__upsert_task',
+        tool_input: { title: 'Draft the roadmap doc' },
+        tool_response: { id: 'task-1' },
+      }),
+      'tool-1',
+      hookOptions,
+    );
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mcp__meeting__upsert_task'),
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Draft the roadmap doc'),
+    );
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('task-1'));
+    expect(result).toEqual({});
+
+    logSpy.mockRestore();
+  });
+
+  it('ignores non-PostToolUse events', async () => {
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+
+    const result = await auditLog(preToolUseInput(), 'tool-1', hookOptions);
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({});
+
+    logSpy.mockRestore();
+  });
+});
+
+describe('createMeetingHooks', () => {
+  it('registers preToolUseGuard and a call budget hook under PreToolUse, and auditLog under PostToolUse', () => {
+    const hooks = createMeetingHooks();
+
+    expect(hooks.PreToolUse).toHaveLength(1);
+    expect(hooks.PreToolUse?.[0].hooks).toHaveLength(2);
+    expect(hooks.PreToolUse?.[0].hooks[0]).toBe(preToolUseGuard);
+
+    expect(hooks.PostToolUse).toHaveLength(1);
+    expect(hooks.PostToolUse?.[0].hooks).toEqual([auditLog]);
+  });
+
+  it('passes its callBudget argument through to the call budget hook', async () => {
+    const hooks = createMeetingHooks(1);
+    const callBudgetHook = hooks.PreToolUse![0].hooks[1];
+
+    await callBudgetHook(preToolUseInput(), 'tool-1', hookOptions);
+    const second = await callBudgetHook(
+      preToolUseInput(),
+      'tool-2',
+      hookOptions,
+    );
+
+    expect(sync(second).hookSpecificOutput).toMatchObject({
+      permissionDecision: 'deny',
+    });
+  });
+});

--- a/apps/api/src/hooks.spec.ts
+++ b/apps/api/src/hooks.spec.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@nestjs/common';
 import type {
   HookJSONOutput,
+  PostToolUseFailureHookInput,
   PostToolUseHookInput,
   PreToolUseHookInput,
   SyncHookJSONOutput,
@@ -45,6 +46,22 @@ function postToolUseInput(
     tool_input: { title: 'Draft the roadmap doc' },
     tool_response: { id: 'task-1' },
     tool_use_id: 'tool-1',
+    ...overrides,
+  };
+}
+
+function postToolUseFailureInput(
+  overrides: Partial<PostToolUseFailureHookInput> = {},
+): PostToolUseFailureHookInput {
+  return {
+    session_id: 'session-1',
+    transcript_path: '/tmp/transcript.jsonl',
+    cwd: '/tmp',
+    hook_event_name: 'PostToolUseFailure',
+    tool_name: 'mcp__meeting__upsert_task',
+    tool_input: { title: 'Draft the roadmap doc' },
+    tool_use_id: 'tool-1',
+    error: 'DB connection reset',
     ...overrides,
   };
 }
@@ -200,7 +217,7 @@ describe('auditLog', () => {
     logSpy.mockRestore();
   });
 
-  it('ignores non-PostToolUse events', async () => {
+  it('ignores non-PostToolUse/PostToolUseFailure events', async () => {
     const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
 
     const result = await auditLog(preToolUseInput(), 'tool-1', hookOptions);
@@ -210,10 +227,64 @@ describe('auditLog', () => {
 
     logSpy.mockRestore();
   });
+
+  it('logs a PostToolUse result with isError: true at warn level, not log', async () => {
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+    const result = await auditLog(
+      postToolUseInput({
+        tool_name: 'mcp__meeting__update_meeting',
+        tool_response: {
+          content: [
+            { type: 'text', text: 'Meeting meeting-1 does not exist.' },
+          ],
+          isError: true,
+        },
+      }),
+      'tool-1',
+      hookOptions,
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mcp__meeting__update_meeting'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('does not exist'),
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({});
+
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('logs a PostToolUseFailure event (a thrown tool handler) at warn level with the error', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+    const result = await auditLog(
+      postToolUseFailureInput({
+        tool_name: 'mcp__meeting__upsert_task',
+        error: 'DB connection reset',
+      }),
+      'tool-1',
+      hookOptions,
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mcp__meeting__upsert_task'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('DB connection reset'),
+    );
+    expect(result).toEqual({});
+
+    warnSpy.mockRestore();
+  });
 });
 
 describe('createMeetingHooks', () => {
-  it('registers preToolUseGuard and a call budget hook under PreToolUse, and auditLog under PostToolUse', () => {
+  it('registers preToolUseGuard and a call budget hook under PreToolUse, and auditLog under PostToolUse/PostToolUseFailure', () => {
     const hooks = createMeetingHooks();
 
     expect(hooks.PreToolUse).toHaveLength(1);
@@ -222,6 +293,8 @@ describe('createMeetingHooks', () => {
 
     expect(hooks.PostToolUse).toHaveLength(1);
     expect(hooks.PostToolUse?.[0].hooks).toEqual([auditLog]);
+    expect(hooks.PostToolUseFailure).toHaveLength(1);
+    expect(hooks.PostToolUseFailure?.[0].hooks).toEqual([auditLog]);
   });
 
   it('passes its callBudget argument through to the call budget hook', async () => {

--- a/apps/api/src/hooks.ts
+++ b/apps/api/src/hooks.ts
@@ -87,24 +87,50 @@ export function createCallBudgetHook(
 }
 
 /**
- * `PostToolUse` hook logging every completed tool call — name, arguments, and result — through
- * Nest's `Logger`. Read-only: it never returns `hookSpecificOutput`, so it can't influence what the
- * agent sees or does.
+ * `PostToolUse`/`PostToolUseFailure` hook logging every completed or failed tool call — name,
+ * arguments, and result/error — through Nest's `Logger`. Read-only: it never returns
+ * `hookSpecificOutput`, so it can't influence what the agent sees or does.
+ *
+ * Registered under both events (see `createMeetingHooks`) because they're mutually exclusive ways
+ * a tool call can finish: `PostToolUse` fires when the tool handler returns normally (including an
+ * MCP tool that reports its own failure via `{ isError: true }`, e.g. `update_meeting` against a
+ * deleted meeting — see `meeting-tools.ts`), `PostToolUseFailure` fires when the handler throws
+ * instead. Logging only `PostToolUse` would silently drop every thrown-exception failure now that
+ * `meeting-tools.ts`'s handlers no longer log their own calls. Both a thrown exception and an
+ * `isError: true` result log at `warn` instead of `log`, so severity-filtered monitoring still
+ * catches them the way the handlers' own `logger.warn` calls used to before this centralized hook
+ * replaced them.
  */
 export const auditLog: HookCallback = (input) => {
+  if (input.hook_event_name === 'PostToolUseFailure') {
+    logger.warn(
+      `tool_name=${input.tool_name} tool_input=${JSON.stringify(input.tool_input)} error=${input.error}`,
+    );
+    return Promise.resolve({});
+  }
+
   if (input.hook_event_name !== 'PostToolUse') {
     return Promise.resolve({});
   }
 
-  logger.log(
-    `tool_name=${input.tool_name} tool_input=${JSON.stringify(input.tool_input)} tool_response=${JSON.stringify(input.tool_response)}`,
-  );
+  const isError =
+    typeof input.tool_response === 'object' &&
+    input.tool_response !== null &&
+    (input.tool_response as { isError?: unknown }).isError === true;
+  const line = `tool_name=${input.tool_name} tool_input=${JSON.stringify(input.tool_input)} tool_response=${JSON.stringify(input.tool_response)}`;
+
+  if (isError) {
+    logger.warn(line);
+  } else {
+    logger.log(line);
+  }
 
   return Promise.resolve({});
 };
 
 /**
- * Assembles `preToolUseGuard`, a fresh `createCallBudgetHook`, and `auditLog` into the
+ * Assembles `preToolUseGuard`, a fresh `createCallBudgetHook`, and `auditLog` — the latter under
+ * both `PostToolUse` and `PostToolUseFailure`, see its own doc comment — into the
  * `Partial<Record<HookEvent, HookCallbackMatcher[]>>` shape `Options.hooks` expects, ready to spread
  * into a `ClaudeAgentService.ask` call's `options`:
  *
@@ -133,5 +159,6 @@ export function createMeetingHooks(
       { hooks: [preToolUseGuard, createCallBudgetHook(callBudget)] },
     ],
     PostToolUse: [{ hooks: [auditLog] }],
+    PostToolUseFailure: [{ hooks: [auditLog] }],
   };
 }

--- a/apps/api/src/hooks.ts
+++ b/apps/api/src/hooks.ts
@@ -1,0 +1,137 @@
+import { Logger } from '@nestjs/common';
+import type {
+  HookCallback,
+  HookCallbackMatcher,
+  HookEvent,
+} from '@anthropic-ai/claude-agent-sdk';
+import { MEETING_TOOLS_SERVER_NAME } from './meeting-tools';
+
+const logger = new Logger('MeetingHooks');
+
+/** Fully-qualified MCP name of the `meeting` server's `upsert_task` tool — see `meeting-tools.ts`. */
+const UPSERT_TASK_TOOL_NAME = `mcp__${MEETING_TOOLS_SERVER_NAME}__upsert_task`;
+
+/**
+ * Below this length an `upsert_task` title is rejected outright. `upsert_task`'s own Zod schema
+ * only requires `title.min(1)` (see `meeting-tools.ts`), which lets through junk like a single
+ * punctuation character or an obviously truncated fragment; this hook enforces the stricter
+ * quality bar the tool schema deliberately doesn't, without changing the schema every other caller
+ * (including tests) relies on.
+ */
+const MIN_TASK_TITLE_LENGTH = 3;
+
+/** Default cap `createCallBudgetHook` enforces when its caller doesn't pass an explicit `limit`. */
+export const DEFAULT_TOOL_CALL_BUDGET = 20;
+
+/**
+ * `PreToolUse` hook denying `mcp__meeting__upsert_task` calls whose `title` is missing, blank, or
+ * shorter than `MIN_TASK_TITLE_LENGTH`. Lets every other tool call through untouched — including
+ * other `upsert_task` calls that already pass the check — by returning `{}` (no
+ * `hookSpecificOutput`, so the SDK falls back to its normal permission flow).
+ */
+export const preToolUseGuard: HookCallback = (input) => {
+  if (
+    input.hook_event_name !== 'PreToolUse' ||
+    input.tool_name !== UPSERT_TASK_TOOL_NAME
+  ) {
+    return Promise.resolve({});
+  }
+
+  const title = (input.tool_input as { title?: unknown } | null)?.title;
+  if (
+    typeof title !== 'string' ||
+    title.trim().length < MIN_TASK_TITLE_LENGTH
+  ) {
+    return Promise.resolve({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: `upsert_task title must be at least ${MIN_TASK_TITLE_LENGTH} non-blank characters, got ${JSON.stringify(title)}.`,
+      },
+    });
+  }
+
+  return Promise.resolve({});
+};
+
+/**
+ * Builds a `PreToolUse` hook that denies every tool call once the run's total tool-call count goes
+ * past `limit` (default `DEFAULT_TOOL_CALL_BUDGET`). The count is kept in a closure, so **each
+ * call to this factory starts its own counter at zero** — callers must call it fresh per agent run
+ * (see `createMeetingHooks` below) rather than sharing one hook instance across runs, or the budget
+ * would apply across unrelated meetings instead of to a single one.
+ */
+export function createCallBudgetHook(
+  limit: number = DEFAULT_TOOL_CALL_BUDGET,
+): HookCallback {
+  let callCount = 0;
+
+  return (input) => {
+    if (input.hook_event_name !== 'PreToolUse') {
+      return Promise.resolve({});
+    }
+
+    callCount += 1;
+    if (callCount > limit) {
+      return Promise.resolve({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: `Tool call budget exceeded: ${callCount}/${limit} tool calls in this run.`,
+        },
+      });
+    }
+
+    return Promise.resolve({});
+  };
+}
+
+/**
+ * `PostToolUse` hook logging every completed tool call — name, arguments, and result — through
+ * Nest's `Logger`. Read-only: it never returns `hookSpecificOutput`, so it can't influence what the
+ * agent sees or does.
+ */
+export const auditLog: HookCallback = (input) => {
+  if (input.hook_event_name !== 'PostToolUse') {
+    return Promise.resolve({});
+  }
+
+  logger.log(
+    `tool_name=${input.tool_name} tool_input=${JSON.stringify(input.tool_input)} tool_response=${JSON.stringify(input.tool_response)}`,
+  );
+
+  return Promise.resolve({});
+};
+
+/**
+ * Assembles `preToolUseGuard`, a fresh `createCallBudgetHook`, and `auditLog` into the
+ * `Partial<Record<HookEvent, HookCallbackMatcher[]>>` shape `Options.hooks` expects, ready to spread
+ * into a `ClaudeAgentService.ask` call's `options`:
+ *
+ * ```ts
+ * const options: Parameters<ClaudeAgentService['ask']>[1] = {
+ *   ...,
+ *   mcpServers: { [MEETING_TOOLS_SERVER_NAME]: meetingToolsServer },
+ *   allowedTools: MEETING_ALLOWED_TOOLS,
+ *   hooks: createMeetingHooks(),
+ * };
+ * await this.claudeAgentService.ask(prompt, options);
+ * ```
+ *
+ * `ClaudeAgentService.ask` forwards `options` (hooks included) straight through to the SDK's
+ * `query({ prompt, options })` call in `claude-agent.module.ts` — there is no separate
+ * registration step beyond passing them here.
+ *
+ * Call this once per agent run (never reuse the returned object across runs) so `callBudget`'s
+ * counter starts fresh each time — see `createCallBudgetHook`.
+ */
+export function createMeetingHooks(
+  callBudget: number = DEFAULT_TOOL_CALL_BUDGET,
+): Partial<Record<HookEvent, HookCallbackMatcher[]>> {
+  return {
+    PreToolUse: [
+      { hooks: [preToolUseGuard, createCallBudgetHook(callBudget)] },
+    ],
+    PostToolUse: [{ hooks: [auditLog] }],
+  };
+}

--- a/apps/api/src/meeting-summary/meeting-summary.service.ts
+++ b/apps/api/src/meeting-summary/meeting-summary.service.ts
@@ -276,6 +276,14 @@ export class MeetingSummaryService {
    * (see above) build the `meeting` MCP tool set once and pass it into every `summarize` call
    * instead of this method rebuilding an identical one (same `meetingId`) on every call; omitted,
    * it builds its own — the shape a caller outside the fold loop (or a test) wants.
+   *
+   * `meetingId` is also passed through to `ClaudeAgentService.ask` purely to tag that run's
+   * cost/usage log line — `runClaudeAgent` (`../claude-agent/claude-agent.module.ts`) is what
+   * installs the `../hooks` policy hooks (`options.hooks` is not set here) and logs
+   * `total_cost_usd`/`usage` once the run's `result` message arrives. `runClaudeAgent` builds a
+   * fresh hook set on every call, so the tool-call budget resets on each retry attempt below rather
+   * than accumulating across them — each attempt is its own agent run either way (see the retry
+   * paragraph above).
    */
   async summarize(
     meetingId: string,
@@ -305,6 +313,7 @@ export class MeetingSummaryService {
         const { text, structuredOutput } = await this.claudeAgentService.ask(
           prompt,
           options,
+          meetingId,
         );
         const reply =
           structuredOutput !== undefined

--- a/apps/api/src/meeting-tools.ts
+++ b/apps/api/src/meeting-tools.ts
@@ -1,8 +1,5 @@
-import { Logger } from '@nestjs/common';
 import { Task, TaskStatus } from '@prisma/client';
 import { z } from 'zod';
-
-const logger = new Logger('MeetingTools');
 
 /**
  * The `meeting` server name and each tool's fully-qualified MCP name
@@ -78,6 +75,10 @@ function errorResult(message: string) {
  * `@anthropic-ai/claude-agent-sdk` is ESM-only, while this app compiles to CommonJS, so `tool` is
  * loaded via a dynamic `import()` rather than a static one — the same reason
  * `claude-agent.module.ts`'s `runClaudeAgent` does.
+ *
+ * None of these handlers log their own call/result — `auditLog` (`./hooks`), wired into every
+ * agent run's `options.hooks.PostToolUse` by `runClaudeAgent`, already logs every tool call's name,
+ * arguments and result centrally; a per-handler `Logger` call here would just duplicate that.
  */
 export async function createMeetingTools(
   meetingId: string,
@@ -96,13 +97,7 @@ export async function createMeetingTools(
         .describe('Free text to match task titles against'),
     },
     async ({ query }) => {
-      logger.log(
-        `find_tasks meetingId=${meetingId} query=${JSON.stringify(query)}`,
-      );
       const matches = await taskService.search(query);
-      logger.log(
-        `find_tasks meetingId=${meetingId} -> ${matches.length} match(es): ${matches.map((m) => m.id).join(', ')}`,
-      );
       return textResult(matches);
     },
     { annotations: { readOnlyHint: true } },
@@ -121,17 +116,11 @@ export async function createMeetingTools(
         ),
     },
     async ({ title, status }) => {
-      logger.log(
-        `upsert_task meetingId=${meetingId} title=${JSON.stringify(title)} status=${status ?? '(unset)'}`,
-      );
       const task = await taskService.upsert({
         title,
         status,
         sourceMeetingId: meetingId,
       });
-      logger.log(
-        `upsert_task meetingId=${meetingId} -> id=${task.id} status=${task.status}`,
-      );
       return textResult(task);
     },
   );
@@ -144,21 +133,14 @@ export async function createMeetingTools(
       decisions: z.array(z.string().min(1)),
     },
     async ({ summary, decisions }) => {
-      logger.log(
-        `update_meeting meetingId=${meetingId} summaryLength=${summary.length} decisions=${decisions.length}`,
-      );
       const updated = await meetingSummaryService.updateContent(
         meetingId,
         summary,
         decisions,
       );
       if (!updated) {
-        logger.warn(
-          `update_meeting meetingId=${meetingId} -> meeting not found`,
-        );
         return errorResult(`Meeting ${meetingId} does not exist.`);
       }
-      logger.log(`update_meeting meetingId=${meetingId} -> ok`);
       return textResult(updated);
     },
   );


### PR DESCRIPTION
## Summary
- Add `apps/api/src/hooks.ts`: `preToolUseGuard` (denies `upsert_task` calls with a title under 3 chars), `createCallBudgetHook` (per-run tool-call cap, default 20), `auditLog` (centralized `PostToolUse` logging), and `createMeetingHooks` assembling all three into `Options.hooks`.
- Wire `createMeetingHooks()` into `runClaudeAgent` (`claude-agent.module.ts`), rebuilt fresh on every call so the call-budget counter never leaks across runs; log `total_cost_usd`/`usage` per run tied to an optional `meetingId` once the SDK's `result` message arrives.
- Thread an optional `meetingId` through `ClaudeAgentRunner`/`ClaudeAgentService.ask`, used only for that log line.
- Drop the now-redundant per-tool `Logger` calls in `meeting-tools.ts` — `auditLog` covers them centrally.
- Update `apps/api/CLAUDE.md` (Layout + a new Invariant on `runClaudeAgent` always overwriting `options.hooks`).

## Test plan
- [x] `pnpm --filter api exec tsc --noEmit`
- [x] `pnpm lint`
- [x] `pnpm test` (apps/api, 148/148 passing, including new `hooks.spec.ts` and `claude-agent.module.spec.ts` which mock the SDK via `jest.unstable_mockModule` — no real Claude Agent SDK calls)
- [x] pre-commit hook (lint + test + test:ralph + check:links) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)